### PR TITLE
feat: update isroot

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -14,7 +14,6 @@ func NewExecCommand() *cobra.Command {
 		DisableFlagsInUseLine: true,
 		SilenceUsage:          true,
 		Args:                  cobra.MinimumNArgs(2),
-		PreRunE:               isRoot,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return internal.Exec(args[0], args[1:], detach)
 		},

--- a/cmd/fork.go
+++ b/cmd/fork.go
@@ -18,7 +18,6 @@ func NewForkCommand() *cobra.Command {
 		Use:          "fork",
 		Hidden:       true,
 		SilenceUsage: true,
-		PreRunE:      isRoot,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := ctr.LoadConfig(); err != nil {
 				return err

--- a/cmd/images.go
+++ b/cmd/images.go
@@ -13,7 +13,6 @@ func NewImagesCommand() *cobra.Command {
 		DisableFlagsInUseLine: true,
 		SilenceUsage:          true,
 		Args:                  cobra.NoArgs,
-		PreRunE:               isRoot,
 		RunE:                  internal.Images,
 	}
 

--- a/cmd/ps.go
+++ b/cmd/ps.go
@@ -13,7 +13,6 @@ func NewPsCommand() *cobra.Command {
 		DisableFlagsInUseLine: true,
 		SilenceUsage:          true,
 		Args:                  cobra.NoArgs,
-		PreRunE:               isRoot,
 		RunE:                  internal.Ps,
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,8 +2,9 @@ package cmd
 
 import (
 	"errors"
-	"github.com/spf13/cobra"
 	"os"
+
+	"github.com/spf13/cobra"
 )
 
 const (
@@ -28,6 +29,7 @@ func NewVesselCommand() *cobra.Command {
 		Short:                 "A tiny tool for managing containers",
 		TraverseChildren:      true,
 		DisableFlagsInUseLine: true,
+		PersistentPreRunE:     isRoot,
 	}
 
 	return cmd

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -13,7 +13,6 @@ func NewRunCommand() *cobra.Command {
 		DisableFlagsInUseLine: true,
 		SilenceUsage:          true,
 		Args:                  cobra.MinimumNArgs(1),
-		PreRunE:               isRoot,
 		RunE:                  internal.Run,
 	}
 


### PR DESCRIPTION
the isroot is duplicated in every command, the `cobra` has an option named `PersistentPreRunE` which all childrens are inherited.

I've fix it :))